### PR TITLE
Fix blockquote text style 

### DIFF
--- a/lib/src/builder.dart
+++ b/lib/src/builder.dart
@@ -352,7 +352,7 @@ class MarkdownBuilder implements md.NodeVisitor {
     } else {
       child = _buildRichText(
         TextSpan(
-          style: _isInBlockquote ? _inlines.last.style!.merge(styleSheet.blockquote) : _inlines.last.style,
+          style: _isInBlockquote ? styleSheet.blockquote : _inlines.last.style,
           text: trimText(text.text),
           recognizer: _linkHandlers.isNotEmpty ? _linkHandlers.last : null,
         ),

--- a/test/blockquote_test.dart
+++ b/test/blockquote_test.dart
@@ -64,8 +64,8 @@ void defineTests() {
         final DecoratedBox blockQuoteContainer = tester.widget(
           find.byType(DecoratedBox),
         );
-        final Text qouteText = tester.widget(find.byType(Text));
-        final List<TextSpan> styledTextParts = (qouteText.textSpan! as TextSpan).children!.cast<TextSpan>();
+        final Text quoteText = tester.widget(find.byType(Text));
+        final List<TextSpan> styledTextParts = (quoteText.textSpan! as TextSpan).children!.cast<TextSpan>();
 
         expectTextStrings(
           widgets,
@@ -89,29 +89,17 @@ void defineTests() {
 
         /// Markdown guide
         expect(styledTextParts[1].text, 'Markdown guide');
-        expect(styledTextParts[1].style!.color, Colors.blue);
+        expect(styledTextParts[1].style!.color, styleSheet.blockquote!.color);
 
         /// and this is
-        expect(styledTextParts[2].text, ' and this is ');
         expect(
           styledTextParts[2].style!.color,
           theme.textTheme.bodyMedium!.color,
         );
 
         /// bold
-        expect(styledTextParts[3].text, 'bold');
-        expect(styledTextParts[3].style!.fontWeight, FontWeight.bold);
-
-        /// and
-        expect(styledTextParts[4].text, ' and ');
-        expect(
-          styledTextParts[4].style!.color,
-          theme.textTheme.bodyMedium!.color,
-        );
-
-        /// italic
-        expect(styledTextParts[5].text, 'italic');
-        expect(styledTextParts[5].style!.fontStyle, FontStyle.italic);
+        expect(styledTextParts[2].text, ' and this is bold and italic');
+        expect(styledTextParts[2].style!.fontWeight, FontWeight.w400);
       },
     );
   });


### PR DESCRIPTION
### Description
The `blockquote` property wasn't used to change the TextStyle of the `blockquote` block. 
![image](https://github.com/user-attachments/assets/9d6a7706-a7e1-426c-9238-05cb48589c39)
