### PR TITLE
Fix null pointer that triggers when adding custom builders

### DIFF
--- a/lib/src/builder.dart
+++ b/lib/src/builder.dart
@@ -278,10 +278,10 @@ class MarkdownBuilder implements md.NodeVisitor {
         element.children!.add(md.Text(''));
       }
 
-      final TextStyle parentStyle = _inlines.last.style!;
+      final TextStyle? parentStyle = _inlines.last.style;
       _inlines.add(_InlineElement(
         tag,
-        style: parentStyle.merge(styleSheet.styles[tag]),
+        style: parentStyle?.merge(styleSheet.styles[tag]),
       ));
     }
 
@@ -697,7 +697,7 @@ class MarkdownBuilder implements md.NodeVisitor {
     if (_inlines.isEmpty) {
       _inlines.add(_InlineElement(
         tag,
-        style: styleSheet.styles[tag!],
+        style: tag != null ? styleSheet.styles[tag] : null,
       ));
     }
   }


### PR DESCRIPTION
When adding a custom syntax and element builder. I get a null pointer within the markdown builder. This PR fixes the issue.

```dart
/// Custom block syntax to detect lines like: [youtube:VIDEO_ID]
class YouTubeBlockSyntax extends md.BlockSyntax {
  static final _pattern = RegExp(r'^\[youtube:([A-Za-z0-9_-]{6,})\]\s*');

  @override
  RegExp get pattern => _pattern;

  @override
  bool canEndBlock(md.BlockParser parser) => true;

  @override
  md.Node? parse(md.BlockParser parser) {
    final currentLine = parser.current.content; // underlying String
    final match = pattern.firstMatch(currentLine); // current line
    if (match == null) return null;
    final videoId = match.group(1);
    if (videoId == null) return null;
    parser.advance();
    return md.Element('youtube', [md.Text(videoId)]);
  }
}

/// Element builder that renders a YouTube iframe player
class YouTubeElementBuilder extends MarkdownElementBuilder {
  YouTubeElementBuilder({this.autoPlay = false});
  final bool autoPlay;

  @override
  Widget? visitElementAfter(md.Element element, TextStyle? preferredStyle) {
    if (element.tag == 'youtube') {
      final videoId = element.textContent.trim();
      return _YouTubePlayerEmbed(videoId: videoId, autoPlay: autoPlay);
    }
    return null;
  }
}
```