### PR TITLE
add noScroll arg in Markdown widget

### DIFF
--- a/lib/src/widget.dart
+++ b/lib/src/widget.dart
@@ -29,12 +29,14 @@ typedef MarkdownOnSelectionChangedCallback = void Function(
 /// Markdown link tag in the document.
 ///
 /// Used by [MarkdownWidget.onTapLink].
-typedef MarkdownTapLinkCallback = void Function(String text, String? href, String title);
+typedef MarkdownTapLinkCallback = void Function(
+    String text, String? href, String title);
 
 /// Signature for custom image widget.
 ///
 /// Used by [MarkdownWidget.imageBuilder]
-typedef MarkdownImageBuilder = Widget Function(Uri uri, String? title, String? alt);
+typedef MarkdownImageBuilder = Widget Function(
+    Uri uri, String? title, String? alt);
 
 /// Signature for custom checkbox widget.
 ///
@@ -135,7 +137,8 @@ abstract class MarkdownElementBuilder {
   ///
   /// If you needn't build a widget, return null.
   @Deprecated('Use visitElementAfterWithContext() instead.')
-  Widget? visitElementAfter(md.Element element, TextStyle? preferredStyle) => null;
+  Widget? visitElementAfter(md.Element element, TextStyle? preferredStyle) =>
+      null;
 }
 
 /// Enum to specify which theme being used when creating [MarkdownStyleSheet]
@@ -223,7 +226,8 @@ abstract class MarkdownWidget extends StatefulWidget {
     this.builders = const <String, MarkdownElementBuilder>{},
     this.paddingBuilders = const <String, MarkdownPaddingBuilder>{},
     this.fitContent = false,
-    this.listItemCrossAxisAlignment = MarkdownListItemCrossAxisAlignment.baseline,
+    this.listItemCrossAxisAlignment =
+        MarkdownListItemCrossAxisAlignment.baseline,
     this.softLineBreak = false,
   });
 
@@ -334,7 +338,8 @@ abstract class MarkdownWidget extends StatefulWidget {
   State<MarkdownWidget> createState() => _MarkdownWidgetState();
 }
 
-class _MarkdownWidgetState extends State<MarkdownWidget> implements MarkdownBuilderDelegate {
+class _MarkdownWidgetState extends State<MarkdownWidget>
+    implements MarkdownBuilderDelegate {
   List<Widget>? _children;
   final List<GestureRecognizer> _recognizers = <GestureRecognizer>[];
 
@@ -347,7 +352,8 @@ class _MarkdownWidgetState extends State<MarkdownWidget> implements MarkdownBuil
   @override
   void didUpdateWidget(MarkdownWidget oldWidget) {
     super.didUpdateWidget(oldWidget);
-    if (widget.data != oldWidget.data || widget.styleSheet != oldWidget.styleSheet) {
+    if (widget.data != oldWidget.data ||
+        widget.styleSheet != oldWidget.styleSheet) {
       _parseMarkdown();
     }
   }
@@ -359,8 +365,10 @@ class _MarkdownWidgetState extends State<MarkdownWidget> implements MarkdownBuil
   }
 
   void _parseMarkdown() {
-    final MarkdownStyleSheet fallbackStyleSheet = kFallbackStyle(context, widget.styleSheetTheme);
-    final MarkdownStyleSheet styleSheet = fallbackStyleSheet.merge(widget.styleSheet);
+    final MarkdownStyleSheet fallbackStyleSheet =
+        kFallbackStyle(context, widget.styleSheetTheme);
+    final MarkdownStyleSheet styleSheet =
+        fallbackStyleSheet.merge(widget.styleSheet);
 
     _disposeRecognizers();
 
@@ -401,7 +409,8 @@ class _MarkdownWidgetState extends State<MarkdownWidget> implements MarkdownBuil
     if (_recognizers.isEmpty) {
       return;
     }
-    final List<GestureRecognizer> localRecognizers = List<GestureRecognizer>.from(_recognizers);
+    final List<GestureRecognizer> localRecognizers =
+        List<GestureRecognizer>.from(_recognizers);
     _recognizers.clear();
     for (final GestureRecognizer recognizer in localRecognizers) {
       recognizer.dispose();
@@ -481,7 +490,8 @@ class MarkdownBody extends MarkdownWidget {
     }
     return Column(
       mainAxisSize: shrinkWrap ? MainAxisSize.min : MainAxisSize.max,
-      crossAxisAlignment: fitContent ? CrossAxisAlignment.start : CrossAxisAlignment.stretch,
+      crossAxisAlignment:
+          fitContent ? CrossAxisAlignment.start : CrossAxisAlignment.stretch,
       children: children,
     );
   }
@@ -522,6 +532,7 @@ class Markdown extends MarkdownWidget {
     this.controller,
     this.physics,
     this.shrinkWrap = false,
+    this.noScroll = false,
     super.softLineBreak,
   });
 
@@ -544,8 +555,23 @@ class Markdown extends MarkdownWidget {
   /// See also: [ScrollView.shrinkWrap]
   final bool shrinkWrap;
 
+  /// Use Row instead of ListView
+  final bool noScroll;
+
   @override
   Widget build(BuildContext context, List<Widget>? children) {
+    if (noScroll) {
+      final List<Widget> childrenWithPadding = [];
+      for (final Widget child in children!) {
+        childrenWithPadding.add(Padding(
+          padding: padding,
+          child: child,
+        ));
+      }
+      return Column(
+        children: childrenWithPadding,
+      );
+    }
     return ListView(
       padding: padding,
       controller: controller,
@@ -559,10 +585,12 @@ class Markdown extends MarkdownWidget {
 /// Parse [task list items](https://github.github.com/gfm/#task-list-items-extension-).
 ///
 /// This class is no longer used as Markdown now supports checkbox syntax natively.
-@Deprecated('Use [OrderedListWithCheckBoxSyntax] or [UnorderedListWithCheckBoxSyntax]')
+@Deprecated(
+    'Use [OrderedListWithCheckBoxSyntax] or [UnorderedListWithCheckBoxSyntax]')
 class TaskListSyntax extends md.InlineSyntax {
   /// Creates a new instance.
-  @Deprecated('Use [OrderedListWithCheckBoxSyntax] or [UnorderedListWithCheckBoxSyntax]')
+  @Deprecated(
+      'Use [OrderedListWithCheckBoxSyntax] or [UnorderedListWithCheckBoxSyntax]')
   TaskListSyntax() : super(_pattern);
 
   static const String _pattern = r'^ *\[([ xX])\] +';

--- a/lib/src/widget.dart
+++ b/lib/src/widget.dart
@@ -561,8 +561,8 @@ class Markdown extends MarkdownWidget {
   @override
   Widget build(BuildContext context, List<Widget>? children) {
     if (noScroll) {
-      final List<Widget> childrenWithPadding = [];
-      for (final Widget child in children!) {
+      final List<Widget> childrenWithPadding = <Widget>[];
+      for (final Widget child in children ?? <Widget>[]) {
         childrenWithPadding.add(Padding(
           padding: padding,
           child: child,


### PR DESCRIPTION
Replaces the default ListView in the Markdown component with Column, enhancing layout compatibility, especially suitable for nested scrolling container scenarios to avoid scrolling conflicts.