### PR TITLE
Change blockquote styles to use theme colors

### DIFF
--- a/lib/src/style_sheet.dart
+++ b/lib/src/style_sheet.dart
@@ -143,10 +143,16 @@ class MarkdownStyleSheet {
       tableColumnWidth: const FlexColumnWidth(),
       tableCellsPadding: const EdgeInsets.fromLTRB(16, 8, 16, 8),
       tableCellsDecoration: const BoxDecoration(),
-      blockquotePadding: const EdgeInsets.all(8.0),
+      blockquotePadding: const EdgeInsets.symmetric(horizontal: 12, vertical: 4),
       blockquoteDecoration: BoxDecoration(
-        color: Colors.blue.shade100,
-        borderRadius: BorderRadius.circular(2.0),
+        color: theme.colorScheme.surfaceContainerHighest,
+        borderRadius: BorderRadius.circular(3),
+        border: Border(
+          left: BorderSide(
+            color: theme.colorScheme.primary,
+            width: 3,
+          ),
+        ),
       ),
       codeblockPadding: const EdgeInsets.all(8.0),
       codeblockDecoration: BoxDecoration(
@@ -318,10 +324,16 @@ class MarkdownStyleSheet {
       tableColumnWidth: const FlexColumnWidth(),
       tableCellsPadding: const EdgeInsets.fromLTRB(16, 8, 16, 8),
       tableCellsDecoration: const BoxDecoration(),
-      blockquotePadding: const EdgeInsets.all(8.0),
+      blockquotePadding: const EdgeInsets.symmetric(horizontal: 12, vertical: 4),
       blockquoteDecoration: BoxDecoration(
-        color: Colors.blue.shade100,
-        borderRadius: BorderRadius.circular(2.0),
+        color: theme.colorScheme.surfaceContainerHighest,
+        borderRadius: BorderRadius.circular(3),
+        border: Border(
+          left: BorderSide(
+            color: theme.colorScheme.primary,
+            width: 3,
+          ),
+        ),
       ),
       codeblockPadding: const EdgeInsets.all(8.0),
       codeblockDecoration: BoxDecoration(


### PR DESCRIPTION
Hi,

the default block quotes used hardcoded colors and I do not want to specify a custom sheet style every time I use a Markdown widget.

These look way better in my opinion:

Before:

<img width="268" height="128" alt="image" src="https://github.com/user-attachments/assets/07198310-0b5c-4fe7-9096-e1db4b3d6f71" />


After:

<img width="268" height="128" alt="image" src="https://github.com/user-attachments/assets/cefeddc4-811d-4f07-a9db-493edb25d9f3" />


I have _not_ touched Cupertino because there are so little colors to choose from.