### PR TITLE
[SER-3966] fix: revert blockquote styling change.

### DIFF
--- a/lib/src/builder.dart
+++ b/lib/src/builder.dart
@@ -358,7 +358,7 @@ class MarkdownBuilder implements md.NodeVisitor {
     } else {
       child = _buildRichText(
         TextSpan(
-          style: _isInBlockquote ? styleSheet.blockquote : _inlines.last.style,
+          style: _isInBlockquote ? styleSheet.blockquote!.merge(_inlines.last.style) : _inlines.last.style,
           text: trimText(text.text),
           recognizer: _linkHandlers.isNotEmpty ? _linkHandlers.last : null,
         ),


### PR DESCRIPTION
**Root Cause:**

https://github.com/foresightmobile/flutter_markdown_plus/pull/2/changes/1adbaa74f99338ff50687a7eb8b7966af6956b6b  this PR in the package deliberately broke this styling behaviour. I don’t know why.

**Implemented Fix:**

Forked the package - at least until they merge a fix in on their end. Specifically changed:

`_isInBlockquote ? styleSheet.blockquote : _inlines.last.style,`

back to

`_isInBlockquote ? styleSheet.blockquote!.merge(_inlines.last.style) : _inlines.last.style`

so ‘blockquote’ elements how merge in the outer style, rather than only applying styleSheet.blockquote. Again, I seriously don’t know why they did this.