### PR TITLE
fix blockquote styling and tests for bold text rendering

### DIFF
--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -29,10 +29,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
+      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.4.1"
   clock:
     dependency: transitive
     description:
@@ -110,18 +110,18 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
+      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.17"
+    version: "0.12.19"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
+      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.11.1"
+    version: "0.13.0"
   meta:
     dependency: transitive
     description:
@@ -187,10 +187,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
+      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.7"
+    version: "0.7.10"
   vector_math:
     dependency: transitive
     description:
@@ -208,5 +208,5 @@ packages:
     source: hosted
     version: "15.0.0"
 sdks:
-  dart: ">=3.8.0-0 <4.0.0"
+  dart: ">=3.9.0-0 <4.0.0"
   flutter: ">=3.27.1"

--- a/lib/src/builder.dart
+++ b/lib/src/builder.dart
@@ -358,7 +358,7 @@ class MarkdownBuilder implements md.NodeVisitor {
     } else {
       child = _buildRichText(
         TextSpan(
-          style: _isInBlockquote ? styleSheet.blockquote : _inlines.last.style,
+          style: _inlines.last.style,
           text: trimText(text.text),
           recognizer: _linkHandlers.isNotEmpty ? _linkHandlers.last : null,
         ),
@@ -726,7 +726,7 @@ class MarkdownBuilder implements md.NodeVisitor {
     if (_inlines.isEmpty) {
       _inlines.add(_InlineElement(
         tag,
-        style: tag != null ? styleSheet.styles[tag] : null,
+        style: _isInBlockquote ? styleSheet.blockquote : (tag != null ? styleSheet.styles[tag] : null),
       ));
     }
   }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -69,10 +69,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
+      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.4.1"
   clock:
     dependency: transitive
     description:
@@ -207,18 +207,18 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
+      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.17"
+    version: "0.12.19"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
+      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.11.1"
+    version: "0.13.0"
   meta:
     dependency: "direct main"
     description:
@@ -324,10 +324,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
+      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.7"
+    version: "0.7.10"
   typed_data:
     dependency: transitive
     description:
@@ -369,5 +369,5 @@ packages:
     source: hosted
     version: "3.1.3"
 sdks:
-  dart: ">=3.8.0-0 <4.0.0"
+  dart: ">=3.9.0-0 <4.0.0"
   flutter: ">=3.27.1"

--- a/test/blockquote_test.dart
+++ b/test/blockquote_test.dart
@@ -87,19 +87,48 @@ void defineTests() {
           theme.textTheme.bodyMedium!.color,
         );
 
-        /// Markdown guide
+        /// Markdown guide (link - should use link color)
         expect(styledTextParts[1].text, 'Markdown guide');
-        expect(styledTextParts[1].style!.color, styleSheet.blockquote!.color);
+        expect(styledTextParts[1].style!.color, Colors.blue);
 
         /// and this is
+        expect(styledTextParts[2].text, ' and this is ');
         expect(
           styledTextParts[2].style!.color,
           theme.textTheme.bodyMedium!.color,
         );
 
-        /// bold
-        expect(styledTextParts[2].text, ' and this is bold and italic');
-        expect(styledTextParts[2].style!.fontWeight, FontWeight.w400);
+        /// bold (should be bold)
+        expect(styledTextParts[3].text, 'bold');
+        expect(styledTextParts[3].style!.fontWeight, FontWeight.bold);
+
+        /// and
+        expect(styledTextParts[4].text, ' and ');
+
+        /// italic (should be italic)
+        expect(styledTextParts[5].text, 'italic');
+        expect(styledTextParts[5].style!.fontStyle, FontStyle.italic);
+      },
+    );
+
+    testWidgets(
+      'bold text in blockquote renders with bold font weight',
+      (WidgetTester tester) async {
+        await tester.pumpWidget(
+          boilerplate(
+            const MarkdownBody(data: '> **bold text**'),
+          ),
+        );
+
+        final Text quoteText = tester.widget(find.byType(Text));
+        final TextSpan textSpan = quoteText.textSpan! as TextSpan;
+
+        // The bold span is either the root span directly (when it's the only element)
+        // or the first child span.
+        final TextSpan boldSpan = textSpan.children != null ? textSpan.children!.cast<TextSpan>().first : textSpan;
+
+        expect(boldSpan.text, 'bold text');
+        expect(boldSpan.style!.fontWeight, FontWeight.bold);
       },
     );
   });


### PR DESCRIPTION
## Fix blockquote inline formatting (bold, italic, links)

Blockquotes were ignoring inline styles — **bold**, *italic*, and link colors inside a > blockquote all rendered without their expected formatting.

**Root cause**: In MarkdownBuilder.visitText, the blockquote check short-circuited to styleSheet.blockquote instead of _inlines.last.style, discarding any styles accumulated by nested strong/em/a elements.

**Changes**:

builder.dart — _addParentInlineIfNeeded now seeds the inline element with the blockquote base style when inside a blockquote; visitText always uses _inlines.last.style (the accumulated style chain).
blockquote_test.dart — Updated the "should work with styling" test to assert correct bold/italic/link rendering; added a dedicated test for bold text inside a blockquote.

Note: this merge request was almost completely made with Claude and Github CoPilot