### PR TITLE
Fix hr tag ignoring custom builders and paddingBuilders

### DIFF
--- a/lib/src/builder.dart
+++ b/lib/src/builder.dart
@@ -474,7 +474,16 @@ class MarkdownBuilder implements md.NodeVisitor {
           child: child,
         );
       } else if (tag == 'hr') {
-        child = Container(decoration: styleSheet.horizontalRuleDecoration);
+        if (!builders.containsKey(tag)) {
+          child = Container(decoration: styleSheet.horizontalRuleDecoration);
+        }
+      }
+
+      if (tag == 'hr' && paddingBuilders.containsKey(tag)) {
+        child = Padding(
+          padding: paddingBuilders[tag]!.getPadding(),
+          child: child,
+        );
       }
 
       _addBlockChild(child);

--- a/test/horizontal_rule_test.dart
+++ b/test/horizontal_rule_test.dart
@@ -2,9 +2,10 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:flutter/widgets.dart';
+import 'package:flutter/material.dart';
 import 'package:flutter_markdown_plus/flutter_markdown_plus.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:markdown/markdown.dart' as md;
 import 'utils.dart';
 
 void main() => defineTests();
@@ -84,5 +85,68 @@ void defineTests() {
         ]);
       },
     );
+    testWidgets(
+      'custom builder for hr is respected',
+      (WidgetTester tester) async {
+        const String data = '---';
+        await tester.pumpWidget(
+          boilerplate(
+            MarkdownBody(
+              data: data,
+              builders: <String, MarkdownElementBuilder>{
+                'hr': _CustomHrBuilder(),
+              },
+            ),
+          ),
+        );
+
+        expect(find.byType(ColoredBox), findsOneWidget);
+        final ColoredBox box = tester.widget(find.byType(ColoredBox));
+        expect(box.color, Colors.red);
+      },
+    );
+
+    testWidgets(
+      'paddingBuilders for hr is applied',
+      (WidgetTester tester) async {
+        const String data = '---';
+        const double paddingX = 16.0;
+        await tester.pumpWidget(
+          boilerplate(
+            MarkdownBody(
+              data: data,
+              paddingBuilders: <String, MarkdownPaddingBuilder>{
+                'hr': _CustomPaddingBuilder(paddingX),
+              },
+            ),
+          ),
+        );
+
+        final Finder paddingFinder = find.byType(Padding);
+        final List<Padding> paddings = tester.widgetList<Padding>(paddingFinder).toList();
+        final bool hasHrPadding = paddings.any(
+          (Padding p) => p.padding.along(Axis.horizontal) == paddingX * 2,
+        );
+        expect(hasHrPadding, isTrue);
+      },
+    );
   });
+}
+
+class _CustomHrBuilder extends MarkdownElementBuilder {
+  @override
+  Widget visitElementAfter(md.Element element, TextStyle? preferredStyle) {
+    return const ColoredBox(color: Colors.red, child: SizedBox(height: 2, width: double.infinity));
+  }
+}
+
+class _CustomPaddingBuilder extends MarkdownPaddingBuilder {
+  _CustomPaddingBuilder(this.paddingX);
+
+  final double paddingX;
+
+  @override
+  EdgeInsets getPadding() {
+    return EdgeInsets.symmetric(horizontal: paddingX);
+  }
 }


### PR DESCRIPTION
## Fix `hr` tag ignoring custom `builders` and `paddingBuilders`

### Problem

When a custom `MarkdownElementBuilder` is registered for the `'hr'` tag via the `builders` map, it is silently ignored. The custom builder's widget is correctly created on **line 397-403** of `builder.dart`:

```dart
Widget child = builders[tag]?.visitElementAfterWithContext(...) ?? defaultChild();
```

But then the `hr` branch on **line 476** unconditionally overwrites `child`:

```dart
} else if (tag == 'hr') {
  child = Container(decoration: styleSheet.horizontalRuleDecoration);
}
```

This discards whatever the custom builder returned and replaces it with the default horizontal rule `Container`. Every other tag's branch (e.g. `li`, `table`, `blockquote`, `pre`) transforms or wraps `child` rather than replacing it outright, so `hr` is uniquely broken in this regard.

A secondary issue affects `paddingBuilders`: entries registered for `'hr'` are never applied. The `paddingBuilders` check for block tags lives inside `_addAnonymousBlockIfNeeded`, which only runs when there is inline content to flush. Since `hr` is a self-closing element with no text content, `_inlines` is always empty when `hr` is processed, so `_addAnonymousBlockIfNeeded` returns early and the padding is never applied.

### Fix

**Custom builders:** The `hr` branch now checks whether a custom builder is registered before applying the default rendering. If `builders` contains an entry for `'hr'`, the widget it produced is preserved:

```dart
} else if (tag == 'hr') {
  if (!builders.containsKey(tag)) {
    child = Container(decoration: styleSheet.horizontalRuleDecoration);
  }
}
```

**Padding builders:** A dedicated `paddingBuilders` check for `'hr'` is applied right before `_addBlockChild`, wrapping `child` in a `Padding` widget. This is scoped specifically to `hr` to avoid double-wrapping tags like `p` and `h1`-`h6` that already receive padding through `_addAnonymousBlockIfNeeded`:

```dart
if (tag == 'hr' && paddingBuilders.containsKey(tag)) {
  child = Padding(
    padding: paddingBuilders[tag]!.getPadding(),
    child: child,
  );
}
```

### Why this approach

- **Minimal change surface** -- only the `hr` code path is modified; no changes to the general block tag pipeline that could affect other elements.
- **Consistent with other tags** -- `li`, `table`, `blockquote`, and `pre` all transform/wrap `child` without discarding custom builder output. This fix brings `hr` in line with that pattern.
- **Scoped padding fix** -- rather than adding a blanket `paddingBuilders` check for all block tags (which would double-pad tags that already go through `_addAnonymousBlockIfNeeded`), the fix targets `hr` specifically since it's the only built-in self-closing block tag that skips that code path.

### Tests

Two new test cases added to `test/horizontal_rule_test.dart`:

- **"custom builder for hr is respected"** -- registers a custom builder that returns a `ColoredBox` and verifies it appears in the widget tree instead of the default `Container` with `horizontalRuleDecoration`.
- **"paddingBuilders for hr is applied"** -- registers a `MarkdownPaddingBuilder` for `'hr'` and verifies the output is wrapped in a `Padding` with the expected insets.

All 366 existing tests continue to pass.