### PR TITLE
Add selectable markdown context menu builder

### DIFF
--- a/lib/src/builder.dart
+++ b/lib/src/builder.dart
@@ -993,7 +993,7 @@ class MarkdownBuilder implements md.NodeVisitor {
         textAlign: textAlign ?? TextAlign.start,
         onSelectionChanged: onSelectionChanged != null
             ? (TextSelection selection, SelectionChangedCause? cause) =>
-                onSelectionChanged!(text.text, selection, cause)
+                onSelectionChanged!(text.toPlainText(), selection, cause)
             : null,
         onTap: onTapText,
         contextMenuBuilder: contextMenuBuilder,

--- a/lib/src/builder.dart
+++ b/lib/src/builder.dart
@@ -114,6 +114,7 @@ class MarkdownBuilder implements md.NodeVisitor {
     this.fitContent = false,
     this.onSelectionChanged,
     this.onTapText,
+    this.contextMenuBuilder,
     this.softLineBreak = false,
   });
 
@@ -161,6 +162,11 @@ class MarkdownBuilder implements md.NodeVisitor {
 
   /// Default tap handler used when [selectable] is set to true
   final VoidCallback? onTapText;
+
+  /// Builds the text selection toolbar when [selectable] is set to true.
+  ///
+  /// Set this to null to suppress the text selection context menu.
+  final EditableTextContextMenuBuilder? contextMenuBuilder;
 
   /// The soft line break is used to identify the spaces at the end of aline of
   /// text and the leading spaces in the immediately following the line of text.
@@ -990,6 +996,7 @@ class MarkdownBuilder implements md.NodeVisitor {
                 onSelectionChanged!(text.text, selection, cause)
             : null,
         onTap: onTapText,
+        contextMenuBuilder: contextMenuBuilder,
         key: k,
       );
     } else {

--- a/lib/src/widget.dart
+++ b/lib/src/widget.dart
@@ -213,6 +213,7 @@ abstract class MarkdownWidget extends StatefulWidget {
     this.onSelectionChanged,
     this.onTapLink,
     this.onTapText,
+    this.contextMenuBuilder = _defaultContextMenuBuilder,
     this.imageDirectory,
     this.blockSyntaxes,
     this.inlineSyntaxes,
@@ -258,6 +259,21 @@ abstract class MarkdownWidget extends StatefulWidget {
 
   /// Default tap handler used when [selectable] is set to true
   final VoidCallback? onTapText;
+
+  /// Builds the text selection toolbar when [selectable] is set to true.
+  ///
+  /// Defaults to the platform-adaptive Flutter text selection toolbar. Set this
+  /// to null to suppress the text selection context menu.
+  final EditableTextContextMenuBuilder? contextMenuBuilder;
+
+  static Widget _defaultContextMenuBuilder(
+    BuildContext context,
+    EditableTextState editableTextState,
+  ) {
+    return AdaptiveTextSelectionToolbar.editableText(
+      editableTextState: editableTextState,
+    );
+  }
 
   /// The base directory holding images referenced by Img tags with local or network file paths.
   final String? imageDirectory;
@@ -391,6 +407,7 @@ class _MarkdownWidgetState extends State<MarkdownWidget> implements MarkdownBuil
       listItemCrossAxisAlignment: widget.listItemCrossAxisAlignment,
       onSelectionChanged: widget.onSelectionChanged,
       onTapText: widget.onTapText,
+      contextMenuBuilder: widget.contextMenuBuilder,
       softLineBreak: widget.softLineBreak,
     );
 
@@ -454,6 +471,7 @@ class MarkdownBody extends MarkdownWidget {
     super.onSelectionChanged,
     super.onTapLink,
     super.onTapText,
+    super.contextMenuBuilder,
     super.imageDirectory,
     super.blockSyntaxes,
     super.inlineSyntaxes,
@@ -508,6 +526,7 @@ class Markdown extends MarkdownWidget {
     super.onSelectionChanged,
     super.onTapLink,
     super.onTapText,
+    super.contextMenuBuilder,
     super.imageDirectory,
     super.blockSyntaxes,
     super.inlineSyntaxes,

--- a/test/context_menu_builder_test.dart
+++ b/test/context_menu_builder_test.dart
@@ -1,0 +1,47 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_markdown_plus/flutter_markdown_plus.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() => defineTests();
+
+void defineTests() {
+  group('contextMenuBuilder', () {
+    testWidgets('uses the default context menu builder when omitted', (WidgetTester tester) async {
+      await tester.pumpWidget(const MaterialApp(home: MarkdownBody(data: 'Selectable text', selectable: true)));
+
+      final SelectableText text = tester.widget<SelectableText>(find.byType(SelectableText));
+
+      expect(text.contextMenuBuilder, isNotNull);
+    });
+
+    testWidgets('can suppress the selectable text context menu', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(home: MarkdownBody(data: 'Selectable text', selectable: true, contextMenuBuilder: null)),
+      );
+
+      final SelectableText text = tester.widget<SelectableText>(find.byType(SelectableText));
+
+      expect(text.contextMenuBuilder, isNull);
+    });
+
+    testWidgets('passes a custom context menu builder to selectable text', (WidgetTester tester) async {
+      Widget customContextMenuBuilder(BuildContext context, EditableTextState editableTextState) {
+        return const SizedBox.shrink();
+      }
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: MarkdownBody(data: 'Selectable text', selectable: true, contextMenuBuilder: customContextMenuBuilder),
+        ),
+      );
+
+      final SelectableText text = tester.widget<SelectableText>(find.byType(SelectableText));
+
+      expect(text.contextMenuBuilder, same(customContextMenuBuilder));
+    });
+  });
+}

--- a/test/context_menu_builder_test.dart
+++ b/test/context_menu_builder_test.dart
@@ -43,5 +43,26 @@ void defineTests() {
 
       expect(text.contextMenuBuilder, same(customContextMenuBuilder));
     });
+
+    testWidgets('selection callback receives rich text as plain text', (WidgetTester tester) async {
+      String? selectedText;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: MarkdownBody(
+            data: 'Selectable **rich** text',
+            selectable: true,
+            onSelectionChanged: (String? text, TextSelection selection, SelectionChangedCause? cause) {
+              selectedText = text;
+            },
+          ),
+        ),
+      );
+
+      final SelectableText text = tester.widget<SelectableText>(find.byType(SelectableText));
+      text.onSelectionChanged?.call(const TextSelection(baseOffset: 0, extentOffset: 10), SelectionChangedCause.drag);
+
+      expect(selectedText, 'Selectable rich text');
+    });
   });
 }


### PR DESCRIPTION
## Summary
- Adds a `contextMenuBuilder` parameter to `Markdown` and `MarkdownBody`.
- Passes the builder through to the internal `SelectableText.rich` widgets when `selectable` is enabled.
- Preserves the existing default Flutter selection toolbar behavior when the parameter is omitted.
- Allows callers to set `contextMenuBuilder: null` to suppress the selectable text context menu.
- Updates selectable markdown selection callbacks to pass `TextSpan.toPlainText()`, so callers receive the full selectable plain text even when markdown produces rich/nested spans.

## Motivation
Apps embedding selectable markdown may already provide their own surrounding context menu. Without a way to customize or suppress the internal `SelectableText` context menu, right-click/long-touch behavior can conflict with the app-level menu.

Also, consumers that implement their own selection-related UI need reliable plain text from `onSelectionChanged`. For rich markdown spans, using only `TextSpan.text` can be null or incomplete, while `toPlainText()` reflects the rendered selectable text.

## Tests
- `flutter test test/context_menu_builder_test.dart`
- `flutter analyze`
